### PR TITLE
Atualizando data do evento BrazilJS 2016.

### DIFF
--- a/_data/events/braziljs2016.yml
+++ b/_data/events/braziljs2016.yml
@@ -1,6 +1,6 @@
 name: BrazilJS
-date: 19/08/2016, 20/08/2016
-url: http://braziljs.org
+date: 26/08/2016, 27/08/2016
+url: https://braziljs.org/conf
 img: https://res.cloudinary.com/dxncj4eza/image/upload/v1452777310/cpxhe5twcbnuzhlvbxkl.png
 description: O maior evento de JS do mundo.
 tags: javascript, front-end


### PR DESCRIPTION
Atualizada a data do evento BrazilJS 2016 para os dias 26 e 27 de agosto de 2016.